### PR TITLE
Gracefully handle unknown orientation

### DIFF
--- a/exif-orient.js
+++ b/exif-orient.js
@@ -55,7 +55,7 @@
       [false, false, -90]  // 8
     ]
 
-    var transform = transforms[orientation - 1]
+    var transform = transforms[orientation - 1] || transforms[0]
     var flipX = transform[0]
     var flipY = transform[1]
     var deg = transform[2]


### PR DESCRIPTION
The script would crash when passing a orientation other than [1-8].
This happens with images without EXIF information. When using the exif-js
library img.exifdata.Orientation is undefined. I think falling back to
no flip/rotation is reasonable in this case.

If you disagree we could still update the docs. The example does not check if `img.exifdata.Orientation` is defined.
